### PR TITLE
updating psr/cache to support Symfony 5.3 & PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^5.6||^7.0||^8.0",
     "symfony/expression-language": ">=2.7",
-    "psr/cache": "^1.0"
+    "psr/cache": "^1.0|^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "*",


### PR DESCRIPTION
Works for me locally. Not 100% sure what the implications are of using psr/cache 2.0 vs 1.0