### PR TITLE
Fix deprecation return type warning for ExpressionFunctionProviderInterface

### DIFF
--- a/src/Constraint/Provider/MatchProvider.php
+++ b/src/Constraint/Provider/MatchProvider.php
@@ -16,7 +16,7 @@ class MatchProvider implements ExpressionFunctionProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return array(
             new ExpressionFunction(


### PR DESCRIPTION
> Method "Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Flagception\Constraint\Provider\MatchProvider" now to avoid errors or add an explicit @return annotation to suppress this message.